### PR TITLE
Changed decoding params

### DIFF
--- a/src/operatore/decoder.py
+++ b/src/operatore/decoder.py
@@ -28,9 +28,9 @@ class Decoder:
             logits,
             hotwords=self.hotwords,
             hotword_weight=self.hotwords_weight,
-            beam_width=150,
-            beam_prune_logp=-45,
-            token_min_logp=-40
+            beam_width=200,
+            beam_prune_logp=-25,
+            token_min_logp=-20
         )
 
         return result

--- a/src/test/decoder.py
+++ b/src/test/decoder.py
@@ -28,9 +28,9 @@ class Decoder:
             logits,
             hotwords=self.hotwords,
             hotword_weight=self.hotwords_weight,
-            beam_width=150,
-            beam_prune_logp=-45,
-            token_min_logp=-40
+            beam_width=200,
+            beam_prune_logp=-25,
+            token_min_logp=-20
         )
 
         return result

--- a/src/test/vad.py
+++ b/src/test/vad.py
@@ -121,8 +121,12 @@ class Vad:
 
                         if (active):
                             try:
+                                start_time = time.perf_counter()
                                 result = self.decoder.decode(audio_array)
                                 result_corrected, cer = self.decoder.post_correction(result)
+                                end_time = time.perf_counter()
+                                elapsed_ms = (end_time - start_time) * 1000
+                                print(f"Time taken for CTC decoder and post correction: {elapsed_ms:.2f} ms")
 
                                 self.__write(f"DECODER: {result_corrected}, CER: {cer} - {int(time.time())}")    # TEST
 
@@ -227,8 +231,13 @@ class Vad:
         # Create a dict with audio metadata
         input_features = {"array": audio_array_normalized, "sampling_rate": 16000}
         # Transcription with Whisper
+        start_time = time.perf_counter()
         transcription = self.pipe(input_features, generate_kwargs={"language": "italian"})["text"]
+        end_time = time.perf_counter()
+        elapsed_ms = (end_time - start_time) * 1000
+        print(f"Time taken for self.pipe(): {elapsed_ms:.2f} ms")
         print(transcription)
+
         return transcription
     
     def __save_audio(self, audio_array):    # TEST


### PR DESCRIPTION
Changed decoding params to 

beam_width=200
beam_prune_logp=-25
token_min_logp=-20 

This should make the ASR faster. Generally token_min_logp is the main contributor to latency and it can be changed further to have faster decoding (trading off accuracy possibly.)